### PR TITLE
FIX #37 : tab bar 사라짐 버그 수정

### DIFF
--- a/Community/CommunityTab.swift
+++ b/Community/CommunityTab.swift
@@ -31,12 +31,10 @@ class CommunityTab: UIViewController {
         self.navigationController?.isNavigationBarHidden = true
         mainView.collection.communities.reloadData()
         reloadData()
-        self.tabBarController?.tabBar.isHidden = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         self.navigationController?.isNavigationBarHidden = false
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     func addTargets() {
@@ -56,12 +54,12 @@ class CommunityTab: UIViewController {
     
     @objc func searchButtonPress() {
         print("search button press")
-        self.navigationController?.pushViewController(SearchCommunity(), animated: true)
+        self.navigationController?.pushViewControllerTabHidden(SearchCommunity(), animated: true)
     }
 
     @objc func addButtonPress() {
         print("add button press")
-        self.navigationController?.pushViewController(CreateCommunityViewController(), animated: false)
+        self.navigationController?.pushViewControllerTabHidden(CreateCommunityViewController(), animated: false)
     }
 
 }
@@ -93,7 +91,7 @@ extension CommunityTab: UICollectionViewDelegate, UICollectionViewDelegateFlowLa
         
         // community 진입
         //print(item.communityTitleLabel.text ?? "default", "진입")
-        self.navigationController?.pushViewController(CommunityInsideViewController(), animated: true)
+        self.navigationController?.pushViewControllerTabHidden(CommunityInsideViewController(), animated: true)
         
     }
     

--- a/MyLib/MyLibTab.swift
+++ b/MyLib/MyLibTab.swift
@@ -29,13 +29,11 @@ class MyLibTab: UIViewController, UICollectionViewDelegate, UICollectionViewDele
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
         dataReload()
-        self.tabBarController?.tabBar.isHidden = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.navigationController?.isNavigationBarHidden = false
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     func dataReload(status: Int = 1, img_url: String = "", title: String = "", author: String = "") {
@@ -109,7 +107,7 @@ extension MyLibTab {
         
         // 북 추가 화면 연결
         if (item.label_title.text == "" && item.label_author.text == "" && item.tag == 0) {
-            self.navigationController?.pushViewController(AddBookBarcode(), animated: false)
+            self.navigationController?.pushViewControllerTabHidden(AddBookBarcode(), animated: true)
         }
         
         // 책 세부 내용 화면 연결
@@ -122,7 +120,7 @@ extension MyLibTab {
                     if let book = book as? [BookDetail] {
                         vc.bookData = book[0]
                     }
-                    self.navigationController?.pushViewController(vc, animated: false)
+                    self.navigationController?.pushViewControllerTabHidden(vc, animated: true)
                 default:
                     print("failed")
                 }

--- a/Utility/Utils.swift
+++ b/Utility/Utils.swift
@@ -58,3 +58,11 @@ extension UIImageView {
         self.load(url: imgURL!)
     }
 }
+
+// MARK: - Tab bar hidden 용 extension
+extension UINavigationController {
+    func pushViewControllerTabHidden(_ viewController: UIViewController, animated: Bool) {
+        viewController.hidesBottomBarWhenPushed = true
+        self.pushViewController(viewController, animated: animated)
+    }
+}


### PR DESCRIPTION
```
// MARK: - Tab bar hidden 용 extension
extension UINavigationController {
    func pushViewControllerTabHidden(_ viewController: UIViewController, animated: Bool) {
        viewController.hidesBottomBarWhenPushed = true
        self.pushViewController(viewController, animated: animated)
    }
}

```

위와 같이 extension 작성해서 네비게이션 Push 되는 화면 진입 시 tab bar 숨겨지도록 해놨습니다.
tab bar가 보이는 navigation root controller에서 push 하는 controller만 이 함수 사용하시면 되고 나머지는 navigation controller에 의해서 자동으로 숨겨지기 때문에 일반 navigation push 함수 사용하시면 됩니다.
궁금하신거 있으시면 알려주세용